### PR TITLE
fix(users-order): fix for translation of label

### DIFF
--- a/src/sharepoint/account/add/sharepoint-account-add.html
+++ b/src/sharepoint/account/add/sharepoint-account-add.html
@@ -20,7 +20,7 @@
                         'has-success': addAccountCtrl.addAccountForm.$valid && addAccountCtrl.addAccountForm.$dirty}">
                     <div class="clearfix">
                         <label class="control-label col-md-4" for="optionPricesQuantity-{{$index}}"
-                               data-ng-bind="option.productName"></label>
+                               data-translate="{{ 'sharepoint_accounts_action_sharepoint_add_product_' + option.planCode }}"></label>
                         <div class="col-md-3">
                             <div data-wuc-increment-number
                                  data-ng-model="option.prices[0].quantity"

--- a/src/sharepoint/translations/Messages_fr_FR.xml
+++ b/src/sharepoint/translations/Messages_fr_FR.xml
@@ -102,6 +102,7 @@
    <translation id="sharepoint_account_action_sharepoint_add_success_message" qtlid="353693">Votre demande a été prise en compte. Vous allez être redirigé vers l'interface de paiement OVH.</translation>
    <translation id="sharepoint_accounts_action_sharepoint_add_error_message" qtlid="353706">Une erreur est survenue lors de la récupération des informations nécessaires à la commande.</translation>
    <translation id="sharepoint_accounts_action_sharepoint_add_error_outofbounds" qtlid="376271">Le nombre de comptes ajoutés doit être compris entre {0} et {1}</translation>
+   <translation id="sharepoint_accounts_action_sharepoint_add_product_sharepoint_account">Compte Sharepoint</translation>
 
    <translation id="sharepoint_action_reset_search" qtlid="279158">Supprimer la recherche</translation>
 


### PR DESCRIPTION
Close MBE-94

### Requirements

While trying to order an account, one of the label's text is displayed in French always. This is because, the value returned by the API is being used directly in the UI.

## Translation fix for Label


### Description of the Change

This has been fixed by adding a translation for the planCode.